### PR TITLE
feat: add analitikTech portfolio landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="tr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>analitikTech | Veri Analisti & Full Stack Developer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <nav class="navbar container">
+        <h1 class="brand">analitikTech</h1>
+        <ul>
+          <li><a href="#hakkimda">Hakkımda</a></li>
+          <li><a href="#projeler">Projeler</a></li>
+          <li><a href="#yetenekler">Yetenekler</a></li>
+          <li><a href="#iletisim">İletişim</a></li>
+        </ul>
+      </nav>
+
+      <section class="container hero-content">
+        <div>
+          <p class="tag">Veri Analisti & Full Stack Developer</p>
+          <h2>Veriyi ürüne, fikri çözüme dönüştüren portfolyo</h2>
+          <p class="intro">
+            analitikTech; veri odaklı düşünmeyi modern web teknolojileriyle birleştiren,
+            gerçek iş problemlerine çözüm üreten projeleri bir araya getirir.
+          </p>
+          <a class="cta" href="#projeler">Projeleri İncele</a>
+        </div>
+        <div class="stats-card">
+          <h3>Kısa Özgeçmiş</h3>
+          <ul>
+            <li><strong>4+</strong> yıl veri analizi deneyimi</li>
+            <li><strong>12+</strong> uçtan uca web uygulaması</li>
+            <li><strong>%28</strong> ortalama süreç verimliliği artışı</li>
+          </ul>
+        </div>
+      </section>
+    </header>
+
+    <main>
+      <section id="hakkimda" class="container section">
+        <h3>Hakkımda</h3>
+        <p>
+          SQL, Python ve BI araçlarıyla veri içgörüsü üretirken; React, Node.js ve
+          PostgreSQL ile ölçeklenebilir ürünler geliştiriyorum. Hedefim teknik derinliği,
+          kullanıcı odaklı deneyimle birleştirmek.
+        </p>
+      </section>
+
+      <section id="projeler" class="container section">
+        <div class="section-head">
+          <h3>Örnek Uygulamalar</h3>
+          <select id="projectFilter" aria-label="Proje filtrele">
+            <option value="all">Tümü</option>
+            <option value="data">Veri Analitiği</option>
+            <option value="fullstack">Full Stack</option>
+          </select>
+        </div>
+
+        <div class="projects">
+          <article class="card" data-type="data">
+            <span class="badge">Veri Analitiği</span>
+            <h4>Satış Tahmin Dashboard'u</h4>
+            <p>
+              Python + Prophet ile satış tahmini, Power BI ile karar destek paneli.
+              Stok planlamasında %18 doğruluk artışı sağladı.
+            </p>
+            <a href="#">Detaylar</a>
+          </article>
+
+          <article class="card" data-type="fullstack">
+            <span class="badge">Full Stack</span>
+            <h4>Akıllı Stok Yönetim Sistemi</h4>
+            <p>
+              React, Node.js ve PostgreSQL tabanlı uygulama. Gerçek zamanlı uyarılar ve
+              rol bazlı yetkilendirme içerir.
+            </p>
+            <a href="#">Detaylar</a>
+          </article>
+
+          <article class="card" data-type="data">
+            <span class="badge">Veri Analitiği</span>
+            <h4>Müşteri Segmentasyonu</h4>
+            <p>
+              K-Means ve RFM analizi ile müşteri segmentleri çıkarıldı,
+              kampanya dönüşüm oranı %22 artırıldı.
+            </p>
+            <a href="#">Detaylar</a>
+          </article>
+
+          <article class="card" data-type="fullstack">
+            <span class="badge">Full Stack</span>
+            <h4>İşe Alım Takip Platformu</h4>
+            <p>
+              Next.js + Prisma ile geliştirilen platform; aday takibi, raporlama ve
+              otomatik e-posta akışları sunar.
+            </p>
+            <a href="#">Detaylar</a>
+          </article>
+        </div>
+      </section>
+
+      <section id="yetenekler" class="container section">
+        <h3>Teknik Yetenekler</h3>
+        <div class="skills">
+          <span>Python</span>
+          <span>SQL</span>
+          <span>Power BI</span>
+          <span>Tableau</span>
+          <span>React</span>
+          <span>Node.js</span>
+          <span>TypeScript</span>
+          <span>PostgreSQL</span>
+          <span>Docker</span>
+          <span>AWS</span>
+        </div>
+      </section>
+
+      <section id="iletisim" class="container section contact">
+        <h3>İletişim</h3>
+        <p>Yeni bir proje fikriniz mi var? Birlikte inşa edelim.</p>
+        <form id="contactForm">
+          <input type="text" placeholder="Ad Soyad" required />
+          <input type="email" placeholder="E-posta" required />
+          <textarea rows="4" placeholder="Mesajınız" required></textarea>
+          <button type="submit">Mesaj Gönder</button>
+        </form>
+        <p id="formMessage" role="status" aria-live="polite"></p>
+      </section>
+    </main>
+
+    <footer>
+      <p>© 2026 analitikTech • Veri odaklı dijital çözümler</p>
+    </footer>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,22 @@
+const filter = document.getElementById("projectFilter");
+const cards = document.querySelectorAll(".card");
+
+filter.addEventListener("change", (event) => {
+  const value = event.target.value;
+
+  cards.forEach((card) => {
+    const type = card.dataset.type;
+    const show = value === "all" || type === value;
+    card.style.display = show ? "block" : "none";
+  });
+});
+
+const contactForm = document.getElementById("contactForm");
+const message = document.getElementById("formMessage");
+
+contactForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+  message.textContent =
+    "Teşekkürler! Mesajın alındı. En kısa sürede seninle iletişime geçeceğim.";
+  contactForm.reset();
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,232 @@
+:root {
+  --bg: #0f172a;
+  --bg-soft: #1e293b;
+  --primary: #38bdf8;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --card: #111827;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: "Inter", sans-serif;
+  background: linear-gradient(180deg, #020617 0%, var(--bg) 30%, #020617 100%);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+.container {
+  width: min(1100px, 92vw);
+  margin: 0 auto;
+}
+
+.hero {
+  padding: 1.5rem 0 4rem;
+}
+
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 0;
+}
+
+.brand {
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--primary);
+}
+
+.navbar ul {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+}
+
+.navbar a {
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.hero-content {
+  margin-top: 2.5rem;
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 2rem;
+  align-items: start;
+}
+
+.tag {
+  color: var(--primary);
+  margin-bottom: 0.7rem;
+  font-weight: 700;
+}
+
+h2 {
+  font-size: clamp(2rem, 4vw, 3.2rem);
+  line-height: 1.2;
+}
+
+.intro {
+  margin: 1.1rem 0 1.5rem;
+  color: var(--muted);
+  max-width: 60ch;
+}
+
+.cta {
+  background: var(--primary);
+  color: #032035;
+  text-decoration: none;
+  font-weight: 700;
+  padding: 0.8rem 1.2rem;
+  border-radius: 0.7rem;
+  display: inline-block;
+}
+
+.stats-card {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid #334155;
+  border-radius: 1rem;
+  padding: 1.2rem;
+}
+
+.stats-card ul {
+  margin-top: 0.9rem;
+  list-style: none;
+  display: grid;
+  gap: 0.7rem;
+}
+
+.section {
+  padding: 2.5rem 0;
+}
+
+.section h3 {
+  font-size: 1.6rem;
+  margin-bottom: 0.9rem;
+}
+
+.section p {
+  color: var(--muted);
+}
+
+.section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+select {
+  background: var(--bg-soft);
+  color: var(--text);
+  border: 1px solid #334155;
+  border-radius: 0.6rem;
+  padding: 0.5rem;
+}
+
+.projects {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid #334155;
+  border-radius: 0.9rem;
+  padding: 1rem;
+}
+
+.badge {
+  font-size: 0.8rem;
+  color: #93c5fd;
+}
+
+.card h4 {
+  margin: 0.45rem 0;
+}
+
+.card a {
+  display: inline-block;
+  margin-top: 0.8rem;
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.skills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.skills span {
+  background: #0b2239;
+  border: 1px solid #1d4f79;
+  color: #bae6fd;
+  border-radius: 999px;
+  padding: 0.4rem 0.8rem;
+  font-size: 0.9rem;
+}
+
+.contact form {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.7rem;
+  max-width: 520px;
+}
+
+input,
+textarea,
+button {
+  font: inherit;
+  border-radius: 0.6rem;
+}
+
+input,
+textarea {
+  padding: 0.75rem;
+  border: 1px solid #334155;
+  background: #0b1221;
+  color: var(--text);
+}
+
+button {
+  padding: 0.75rem;
+  border: none;
+  background: var(--primary);
+  color: #032035;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+#formMessage {
+  margin-top: 0.8rem;
+  color: #86efac;
+}
+
+footer {
+  border-top: 1px solid #1e293b;
+  margin-top: 2rem;
+  padding: 1.2rem;
+  text-align: center;
+  color: var(--muted);
+}
+
+@media (max-width: 850px) {
+  .hero-content,
+  .projects {
+    grid-template-columns: 1fr;
+  }
+
+  .navbar {
+    flex-direction: column;
+    gap: 0.7rem;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a single-page portfolio for a combined Data Analyst & Full Stack Developer persona named `analitikTech` to showcase sample projects and technical skills.
- Include both data-analytics and full-stack example projects so the portfolio highlights cross-discipline experience.
- Deliver a lightweight, responsive static site that can be previewed locally without additional build tooling.

### Description
- Add `index.html` which contains hero, `Hakkımda` (about), `Örnek Uygulamalar` (projects), `Yetenekler` (skills), `İletişim` (contact) and footer sections with Turkish content and sample project cards.  
- Add `styles.css` that implements a dark-themed, responsive layout, typography (Inter), card styles, and mobile breakpoints.  
- Add `script.js` which implements project filtering via the `#projectFilter` select (cards use `data-type`) and a simple contact form handler on `#contactForm` that prevents submit and displays a success message.  
- Small accessibility touches such as `aria-label` on the project filter and `role="status" aria-live="polite"` for the form message were included.

### Testing
- Served the site locally using `python3 -m http.server 4173` and confirmed assets loaded successfully (server returned HTTP 200 for `index.html`, `styles.css`, and `script.js`). — succeeded.  
- Captured a full-page screenshot of `http://127.0.0.1:4173` using the Playwright helper `mcp__browser_tools__run_playwright_script` to validate visual rendering — succeeded.  
- Verified the repository working tree to ensure the three new files are present after changes — succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999c5637a1c832ebd9f5a01cd5e10f3)